### PR TITLE
fix: format link support up to 63 chars length top-level-domain

### DIFF
--- a/packages/depub.space/src/utils/messageSanitizer/messageSanitizer.spec.ts
+++ b/packages/depub.space/src/utils/messageSanitizer/messageSanitizer.spec.ts
@@ -19,6 +19,15 @@ describe('messageSanitizer', () => {
         'ABC中文 <a href="https://abc.com/中文" target="_blank" rel="noopener noreferrer">https://abc.com/中文</a> 中文 #XYZ <a href="https://繁中.com/中文?name=壹貳參" target="_blank" rel="noopener noreferrer">https://繁中.com/中文?name=壹貳參</a>'
       );
     });
+
+    it('should extract URLs with long top level domain', () => {
+      const test = 'ABC中文 https://abc.network 中文 #XYZ https://繁中.network/中文?name=壹貳參';
+      const result = replaceURLToAnchor(test);
+
+      expect(result).toBe(
+        'ABC中文 <a href="https://abc.network" target="_blank" rel="noopener noreferrer">https://abc.network</a> 中文 #XYZ <a href="https://繁中.network/中文?name=壹貳參" target="_blank" rel="noopener noreferrer">https://繁中.network/中文?name=壹貳參</a>'
+      );
+    });
   });
 
   describe('replaceTagToAnchor', () => {

--- a/packages/depub.space/src/utils/messageSanitizer/messageSanitizer.ts
+++ b/packages/depub.space/src/utils/messageSanitizer/messageSanitizer.ts
@@ -4,7 +4,7 @@ export function removeHtmlTags(html: string) {
 
 export const replaceURLToAnchor = (content: string): string => {
   const urlRegex =
-    /https?:\/\/(www\.)?[-a-zA-Z0-9\u00a1-\uffff@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9\u00a1-\uffff()@:%_+.~#?&//=\p{L}]*)/g;
+    /https?:\/\/(www\.)?[-a-zA-Z0-9\u00a1-\uffff@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,63}\b([-a-zA-Z0-9\u00a1-\uffff()@:%_+.~#?&//=\p{L}]*)/g;
 
   return content.replace(urlRegex, url => {
     let hyperlink = url;


### PR DESCRIPTION
fix for issue #92 
https://github.com/depub-team/depub.space/issues/92